### PR TITLE
setting battery level also in hid, if it was created, yet

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -89,7 +89,7 @@ static const uint8_t _hidReportDescriptor[] = {
   END_COLLECTION(0)                  // END_COLLECTION
 };
 
-BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer, uint8_t batteryLevel)
+BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer, uint8_t batteryLevel) : hid(0)
 {
   this->deviceName = deviceName;
   this->deviceManufacturer = deviceManufacturer;
@@ -112,6 +112,8 @@ bool BleKeyboard::isConnected(void) {
 
 void BleKeyboard::setBatteryLevel(uint8_t level) {
   this->batteryLevel = level;
+  if (hid != 0)
+    this->hid->setBatteryLevel(this->batteryLevel);
 }
 
 void BleKeyboard::taskServer(void* pvParameter) {

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -89,7 +89,6 @@ typedef struct
 class BleKeyboard : public Print
 {
 private:
-  uint8_t _buttons;
   BleConnectionStatus* connectionStatus;
   BLEHIDDevice* hid;
   BLECharacteristic* inputKeyboard;
@@ -97,7 +96,6 @@ private:
   BLECharacteristic* inputMediaKeys;
   KeyReport _keyReport;
   MediaKeyReport _mediaKeyReport;
-  void buttons(uint8_t b);
   static void taskServer(void* pvParameter);
 public:
   BleKeyboard(std::string deviceName = "ESP32 BLE Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);


### PR DESCRIPTION
- To be able to update the batteryLevel of the HID, it has to call the setBatteryLevel() method of the HID
- removed unused buttons member and method