### PR TITLE
enable static pin as parameter for begin()

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -99,10 +99,15 @@ BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer,
   this->connectionStatus = new BleConnectionStatus();
 }
 
-void BleKeyboard::begin(uint32_t pin)
+void BleKeyboard::begin()
+{
+  xTaskCreate(this->taskServer, "server", 20000, (void *)this, 5, NULL);
+}
+
+void BleKeyboard::beginPIN(uint32_t pin)
 {
   _pin = pin;
-  xTaskCreate(this->taskServer, "server", 20000, (void *)this, 5, NULL);
+  begin();
 }
 
 void BleKeyboard::end(void)

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -100,7 +100,8 @@ private:
   static void taskServer(void* pvParameter);
 public:
   BleKeyboard(std::string deviceName = "ESP32 BLE Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
-  void begin(uint32_t pin = 0);
+  void begin();
+  void beginPIN(uint32_t pin);
   void end(void);
   void sendReport(KeyReport* keys);
   void sendReport(MediaKeyReport* keys);


### PR DESCRIPTION
To have a simple way of protected pairing, an optional parameter can be
specified to used as a pin for authentication. Tested on a Linux system.

Signed-off-by: Sven Oliver Moll <svolli@svolli.de>