### PR TITLE
Change to no bond

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -139,7 +139,10 @@ void BleKeyboard::taskServer(void* pvParameter) {
 
   BLESecurity *pSecurity = new BLESecurity();
 
-  pSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
+  //https://github.com/nkolban/esp32-snippets/issues/230#issuecomment-554595413
+  //pSecurity->setAuthenticationMode(ESP_LE_AUTH_BOND);
+  pSecurity->setAuthenticationMode(ESP_LE_AUTH_NO_BOND);
+  pSecurity->setCapability(ESP_IO_CAP_NONE);
 
   bleKeyboardInstance->hid->reportMap((uint8_t*)_hidReportDescriptor, sizeof(_hidReportDescriptor));
   bleKeyboardInstance->hid->startServices();


### PR DESCRIPTION
Implement change suggested by ossvr at
https://github.com/nkolban/esp32-snippets/issues/230#issuecomment-554595413

This solved reconnection problem I faced with Macbook Pro with MacOS Catalina