### PR TITLE
Added a new onAdvertising hook

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -149,6 +149,9 @@ void BleKeyboard::taskServer(void* pvParameter) {
   BLEAdvertising *pAdvertising = pServer->getAdvertising();
   pAdvertising->setAppearance(HID_KEYBOARD);
   pAdvertising->addServiceUUID(bleKeyboardInstance->hid->hidService()->getUUID());
+
+  bleKeyboardInstance->onAdvertising(pAdvertising);
+
   pAdvertising->start();
   bleKeyboardInstance->hid->setBatteryLevel(bleKeyboardInstance->batteryLevel);
 

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -118,6 +118,7 @@ public:
   std::string deviceName;
 protected:
   virtual void onStarted(BLEServer *pServer) { };
+  virtual void onAdvertising(BLEAdvertising *pAdvertising) { };
 };
 
 #endif // CONFIG_BT_ENABLED


### PR DESCRIPTION
Hi there,

I just added an onAdvertising hook that works in conjunction with the previously merged onStarted hook.

Here's an example where the ESP32 advertises itself as a BLE MIDI device and a BLE Keyboard at the same time:
```cpp
#include <Arduino.h>
#include <BleKeyboard.h>

#define SERVICE_UUID        "03b80e5a-ede8-4b33-a751-6ce34ec4c700"
#define CHARACTERISTIC_UUID "7772e5db-3868-4112-a1a9-f2669d106bf3"

class CustomBLE : public BleKeyboard {
  private:
    BLEService *midiService;
  public:
    BLECharacteristic *midiCharacteristic;
    CustomBLE(const char *deviceName, const char *manufacturer) : BleKeyboard(deviceName, manufacturer) {}
  protected:
    void onStarted(BLEServer *pServer) override {
      midiService = pServer->createService(BLEUUID(SERVICE_UUID));

      midiCharacteristic = midiService->createCharacteristic(
        BLEUUID(CHARACTERISTIC_UUID),
        BLECharacteristic::PROPERTY_READ   |
        BLECharacteristic::PROPERTY_WRITE  |
        BLECharacteristic::PROPERTY_NOTIFY |
        BLECharacteristic::PROPERTY_WRITE_NR
      );

      midiCharacteristic->addDescriptor(new BLE2902());

      midiService->start();
    }

    void onAdvertising(BLEAdvertising *pAdvertising) override {
      pAdvertising->addServiceUUID(midiService->getUUID());
    }
};

static CustomBLE customBLEKeyboard("BLE MIDI + Keyboard", "akosbeke");
uint8_t midiPacket[] = {
   0x80,  // header
   0x80,  // timestamp, not implemented 
   0x00,  // status
   0x3c,  // 0x3c == 60 == middle c
   0x00   // velocity
};

void setup() {
  customBLEKeyboard.begin();
}

void loop() {
  if(customBLEKeyboard.isConnected()) {
    customBLEKeyboard.write(KEY_RIGHT_ARROW);

    delay(1000);

    // note down
    midiPacket[2] = 0x90; // note down, channel 0
    midiPacket[4] = 127;  // velocity
    customBLEKeyboard.midiCharacteristic->setValue(midiPacket, 5); // packet, length in bytes
    customBLEKeyboard.midiCharacteristic->notify();

    // play note for 500ms
    delay(500);

    // note up
    midiPacket[2] = 0x80; // note up, channel 0
    midiPacket[4] = 0;    // velocity
    customBLEKeyboard.midiCharacteristic->setValue(midiPacket, 5); // packet, length in bytes)
    customBLEKeyboard.midiCharacteristic->notify();

    delay(500);
  }
}
```

Please consider merging it.