### PR TITLE
Set ScanResponse to off so the advertising will actually advertise...

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -149,6 +149,7 @@ void BleKeyboard::taskServer(void* pvParameter) {
   BLEAdvertising *pAdvertising = pServer->getAdvertising();
   pAdvertising->setAppearance(HID_KEYBOARD);
   pAdvertising->addServiceUUID(bleKeyboardInstance->hid->hidService()->getUUID());
+  pAdvertising->setScanResponse(false);
   pAdvertising->start();
   bleKeyboardInstance->hid->setBatteryLevel(bleKeyboardInstance->batteryLevel);
 


### PR DESCRIPTION
…the name.
See [this line](https://github.com/nkolban/esp32-snippets/blob/fe3d318acddf87c6918944f24e8b899d63c816dd/cpp_utils/BLEAdvertising.cpp#L213) for why.