### PR TITLE
Update BleKeyboard.cpp

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -97,13 +97,17 @@ BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer,
   this->connectionStatus = new BleConnectionStatus();
 }
 
+
+TaskHandle_t xHandle = NULL;
+
 void BleKeyboard::begin(void)
 {
-  xTaskCreate(this->taskServer, "server", 20000, (void *)this, 5, NULL);
+  xTaskCreate(this->taskServer, "server", 20000, (void *)this, 5, &xHandle);
 }
 
 void BleKeyboard::end(void)
 {
+    vTaskDelete(xHandle);
 }
 
 bool BleKeyboard::isConnected(void) {


### PR DESCRIPTION
Edited BleKeyboard::begin and BleKeyboard::end to be able to delete the Task when stopping BleKeyboard. I had the need for this to so I could stop ESP32-BLE-Keyboard and start AsyncWebServer.

If you create a task like this:

`TaskHandle_t xHandle = NULL;`

`void BleKeyboard::begin(void)
{
  xTaskCreate(this->taskServer, "server", 20000, (void *)this, 5, &xHandle);
}
`

You will be able to delete the task using BleKeyboard.end();

`void BleKeyboard::end(void)
{
    vTaskDelete(xHandle);
}
`