### PR TITLE
Add Read Numlock/Capslock/Scrolllock state

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -106,6 +106,11 @@ void BleKeyboard::end(void)
 {
 }
 
+void BleKeyboard::setLedChangeCallBack(void (*func)(KbdLeds*))
+{
+	keyboardOutputCallBack->func = func;
+}
+
 bool BleKeyboard::isConnected(void) {
   return this->connectionStatus->connected;
 }
@@ -128,9 +133,10 @@ void BleKeyboard::taskServer(void* pvParameter) {
   bleKeyboardInstance->inputMediaKeys = bleKeyboardInstance->hid->inputReport(MEDIA_KEYS_ID);
   bleKeyboardInstance->connectionStatus->inputKeyboard = bleKeyboardInstance->inputKeyboard;
   bleKeyboardInstance->connectionStatus->outputKeyboard = bleKeyboardInstance->outputKeyboard;
-	bleKeyboardInstance->connectionStatus->inputMediaKeys = bleKeyboardInstance->inputMediaKeys;
+  bleKeyboardInstance->connectionStatus->inputMediaKeys = bleKeyboardInstance->inputMediaKeys;
 
-  bleKeyboardInstance->outputKeyboard->setCallbacks(new KeyboardOutputCallbacks());
+  bleKeyboardInstance->keyboardOutputCallBack = new KeyboardOutputCallbacks();
+  bleKeyboardInstance->outputKeyboard->setCallbacks(bleKeyboardInstance->keyboardOutputCallBack);
 
   bleKeyboardInstance->hid->manufacturer()->setValue(bleKeyboardInstance->deviceManufacturer);
 

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -3,11 +3,12 @@
 #include "sdkconfig.h"
 #if defined(CONFIG_BT_ENABLED)
 
+#include <Arduino.h>
+#include "KeyboardOutputCallbacks.h"
 #include "BleConnectionStatus.h"
 #include "BLEHIDDevice.h"
 #include "BLECharacteristic.h"
 #include "Print.h"
-
 
 const uint8_t KEY_LEFT_CTRL = 0x80;
 const uint8_t KEY_LEFT_SHIFT = 0x81;
@@ -33,6 +34,8 @@ const uint8_t KEY_PAGE_DOWN = 0xD6;
 const uint8_t KEY_HOME = 0xD2;
 const uint8_t KEY_END = 0xD5;
 const uint8_t KEY_CAPS_LOCK = 0xC1;
+const uint8_t KEY_NUM_LOCK = 0xDB;
+const uint8_t KEY_SCROLL_LOCK = 0xCF;
 const uint8_t KEY_F1 = 0xC2;
 const uint8_t KEY_F2 = 0xC3;
 const uint8_t KEY_F3 = 0xC4;
@@ -78,7 +81,7 @@ const MediaKeyReport KEY_MEDIA_CONSUMER_CONTROL_CONFIGURATION = {0, 64}; // Medi
 const MediaKeyReport KEY_MEDIA_EMAIL_READER = {0, 128};
 
 
-//  Low level key report: up to 6 keys and shift, ctrl etc at once
+//  Low level key report: up to 6 keys and shift, ctrl etc at once // struct clone form USB_Host_Shield_2.0-master :D
 typedef struct
 {
   uint8_t modifiers;
@@ -89,7 +92,8 @@ typedef struct
 class BleKeyboard : public Print
 {
 private:
-  BleConnectionStatus* connectionStatus;
+  KeyboardOutputCallbacks* keyboardOutputCallBack;
+  BleConnectionStatus* connectionStatus; 
   BLEHIDDevice* hid;
   BLECharacteristic* inputKeyboard;
   BLECharacteristic* outputKeyboard;
@@ -98,9 +102,10 @@ private:
   MediaKeyReport _mediaKeyReport;
   static void taskServer(void* pvParameter);
 public:
-  BleKeyboard(std::string deviceName = "ESP32 BLE Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
+  BleKeyboard(std::string deviceName = "ESP32_BLE_Keyboard_Test", std::string deviceManufacturer = "DIY", uint8_t batteryLevel = 100);
   void begin(void);
   void end(void);
+  void setLedChangeCallBack(void (*func)(KbdLeds*));
   void sendReport(KeyReport* keys);
   void sendReport(MediaKeyReport* keys);
   size_t press(uint8_t k);
@@ -117,7 +122,8 @@ public:
   std::string deviceManufacturer;
   std::string deviceName;
 protected:
-  virtual void onStarted(BLEServer *pServer) { };
+  virtual void onStarted(BLEServer *pServer) { 
+  };
 };
 
 #endif // CONFIG_BT_ENABLED

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -3,7 +3,6 @@
 #include "sdkconfig.h"
 #if defined(CONFIG_BT_ENABLED)
 
-#include <Arduino.h>
 #include "KeyboardOutputCallbacks.h"
 #include "BleConnectionStatus.h"
 #include "BLEHIDDevice.h"
@@ -102,7 +101,7 @@ private:
   MediaKeyReport _mediaKeyReport;
   static void taskServer(void* pvParameter);
 public:
-  BleKeyboard(std::string deviceName = "ESP32_BLE_Keyboard_Test", std::string deviceManufacturer = "DIY", uint8_t batteryLevel = 100);
+  BleKeyboard(std::string deviceName = "ESP32 BLE Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
   void begin(void);
   void end(void);
   void setLedChangeCallBack(void (*func)(KbdLeds*));
@@ -122,8 +121,7 @@ public:
   std::string deviceManufacturer;
   std::string deviceName;
 protected:
-  virtual void onStarted(BLEServer *pServer) { 
-  };
+  virtual void onStarted(BLEServer *pServer) { };
 };
 
 #endif // CONFIG_BT_ENABLED

--- a/KeyboardOutputCallbacks.cpp
+++ b/KeyboardOutputCallbacks.cpp
@@ -16,4 +16,4 @@ void KeyboardOutputCallbacks::onWrite(BLECharacteristic* me) {
   ESP_LOGI(LOG_TAG, "special keys: %d", *kbled);
   // if(func!=NULL)
   func(kbled);
-}      
+}

--- a/KeyboardOutputCallbacks.cpp
+++ b/KeyboardOutputCallbacks.cpp
@@ -12,7 +12,8 @@ KeyboardOutputCallbacks::KeyboardOutputCallbacks(void) {
 }
 
 void KeyboardOutputCallbacks::onWrite(BLECharacteristic* me) {
-  uint8_t* value = (uint8_t*)(me->getValue().c_str());
-  ESP_LOGI(LOG_TAG, "special keys: %d", *value);
-}
-
+  KbdLeds* kbled = (KbdLeds*)(me->getValue().c_str());
+  ESP_LOGI(LOG_TAG, "special keys: %d", *kbled);
+  // if(func!=NULL)
+  func(kbled);
+}      

--- a/KeyboardOutputCallbacks.h
+++ b/KeyboardOutputCallbacks.h
@@ -7,12 +7,23 @@
 #include "BLE2902.h"
 #include "BLECharacteristic.h"
 
+// key report back
+typedef struct{
+        uint8_t bmNumLock : 1;
+        uint8_t bmCapsLock : 1;
+        uint8_t bmScrollLock : 1;
+        uint8_t bmCompose : 1;
+        uint8_t bmKana : 1;
+        uint8_t bmReserved : 3;
+} KbdLeds;
+using callBackFunc = void (*)(KbdLeds*);
+
 class KeyboardOutputCallbacks : public BLECharacteristicCallbacks
 {
 public:
+  callBackFunc func; //= [](KbdLeds*){ }
   KeyboardOutputCallbacks(void);
   void onWrite(BLECharacteristic* me);
 };
-
 #endif // CONFIG_BT_ENABLED
 #endif // ESP32_BLE_KEYBOARD_OUTPUT_CALLBACKS_H

--- a/KeyboardOutputCallbacks.h
+++ b/KeyboardOutputCallbacks.h
@@ -21,7 +21,7 @@ using callBackFunc = void (*)(KbdLeds*);
 class KeyboardOutputCallbacks : public BLECharacteristicCallbacks
 {
 public:
-  callBackFunc func; //= [](KbdLeds*){ }
+  callBackFunc func = [](KbdLeds*){ };
   KeyboardOutputCallbacks(void);
   void onWrite(BLECharacteristic* me);
 };

--- a/examples/SendKeyStrokes/ReadWriteNumLock.ino
+++ b/examples/SendKeyStrokes/ReadWriteNumLock.ino
@@ -1,0 +1,29 @@
+/**
+ * This example turns the ESP32 into a Bluetooth LE keyboard that you can use num/caps/scroll lock led for some reason ex:  turn your room light by scroll lock :))) 
+ */
+#include <BleKeyboard.h>
+
+BleKeyboard bleKeyboard;
+
+//note that this function should run "fast" or esp will crash
+void KbdLedCb(KbdLeds *kbls)
+{
+    digitalWrite(2,kbls->bmNumLock);
+    // digitalWrite(2,kbls->bmCapsLock);
+    // digitalWrite(2,kbls->bmScrollLock);
+    // ...
+}
+
+void setup() {
+  pinMode(2,OUTPUT);
+  Serial.begin(115200);
+  Serial.println("Starting BLE work!");     
+  bleKeyboard.begin();
+  delay(1000);//must have delay for the BLE  finish inital
+  bleKeyboard.setLedChangeCallBack(KbdLedCb);
+}
+
+void loop() {
+  bleKeyboard.write(KEY_NUM_LOCK);
+  delay(10000);
+}


### PR DESCRIPTION
Thank you for your repository, I transformed my wire [keyboard ](https://github.com/Cemu0/ESP32_USBHOST_TO_BLE_KEYBOARD) to wireless :) 
When type on the numpad the Numlock stage should be sync or the numpad just run wrong, same with caplock stage. 
I also added an example for demonstration.
Hope this helpful 