### PR TITLE
Update BleKeyboard.h

### DIFF
--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -113,6 +113,7 @@ public:
   void releaseAll(void);
   bool isConnected(void);
   void setBatteryLevel(uint8_t level);
+  void setName(std::string deviceName);  
   uint8_t batteryLevel;
   std::string deviceManufacturer;
   std::string deviceName;


### PR DESCRIPTION
added setName function to allow changing the name of the device using a stored preference (must be called before begin).