### PR TITLE
Add small delay for writes

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -472,6 +472,7 @@ void BleKeyboard::releaseAll(void)
 size_t BleKeyboard::write(uint8_t c)
 {
 	uint8_t p = press(c);  // Keydown
+	delay_ms(_delay_ms);   // Wait to make sure this registers for long writes with many keystrokes
 	release(c);            // Keyup
 	return p;              // just return the result of press() since release() almost always returns 1
 }


### PR DESCRIPTION
For long strings, the `write` function skips a bunch of keys. This is on Windows 10, not sure if it affects other platforms or not.

Adding few millisecond delay between the key press and release solved it for me. I'm happy to make changes/corrections to my PR if needed!