### PR TITLE
Allow server initialisation to happen outside of begin()

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -101,11 +101,20 @@ BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer,
     , deviceManufacturer(std::string(deviceManufacturer).substr(0,15))
     , batteryLevel(batteryLevel) {}
 
+void BleKeyboard::init(void)
+{
+  if(!initialised) {
+    BLEDevice::init(deviceName);
+    BLEServer* pServer = BLEDevice::createServer();
+    pServer->setCallbacks(this);
+    initialised = true;
+  }
+}
+
 void BleKeyboard::begin(void)
 {
-  BLEDevice::init(deviceName);
+  init();
   BLEServer* pServer = BLEDevice::createServer();
-  pServer->setCallbacks(this);
 
   hid = new BLEHIDDevice(pServer);
   inputKeyboard = hid->inputReport(KEYBOARD_ID);  // <-- input REPORTID from report map

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -144,6 +144,7 @@ private:
   bool               connected = false;
   uint32_t           _delay_ms = 7;
   void delay_ms(uint64_t ms);
+  bool               initialised = false;
 
   uint16_t vid       = 0x05ac;
   uint16_t pid       = 0x820a;
@@ -152,6 +153,7 @@ private:
 public:
   BleKeyboard(std::string deviceName = "ESP32 Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
   void begin(void);
+  void init(void);
   void end(void);
   void sendReport(KeyReport* keys);
   void sendReport(MediaKeyReport* keys);


### PR DESCRIPTION
By separating the server initialisation from the begin() method it's possible to add other GATT services to the server before the HID services and advertisement is started later on.

This would help with situations like #73 