### PR TITLE
Preventing collissions

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -186,11 +186,11 @@ void BleKeyboard::set_version(uint16_t version) {
 	this->version = version; 
 }
 
-void BleKeyboard::sendReport(KeyReport* keys)
+void BleKeyboard::sendReport(BleKeyReport* keys)
 {
   if (this->isConnected())
   {
-    this->inputKeyboard->setValue((uint8_t*)keys, sizeof(KeyReport));
+    this->inputKeyboard->setValue((uint8_t*)keys, sizeof(BleKeyReport));
     this->inputKeyboard->notify();
 #if defined(USE_NIMBLE)        
     // vTaskDelay(delayTicks);
@@ -199,11 +199,11 @@ void BleKeyboard::sendReport(KeyReport* keys)
   }	
 }
 
-void BleKeyboard::sendReport(MediaKeyReport* keys)
+void BleKeyboard::sendReport(BleMediaKeyReport* keys)
 {
   if (this->isConnected())
   {
-    this->inputMediaKeys->setValue((uint8_t*)keys, sizeof(MediaKeyReport));
+    this->inputMediaKeys->setValue((uint8_t*)keys, sizeof(BleMediaKeyReport));
     this->inputMediaKeys->notify();
 #if defined(USE_NIMBLE)        
     //vTaskDelay(delayTicks);
@@ -397,7 +397,7 @@ size_t BleKeyboard::press(uint8_t k)
 	return 1;
 }
 
-size_t BleKeyboard::press(const MediaKeyReport k)
+size_t BleKeyboard::press(const BleMediaKeyReport k)
 {
     uint16_t k_16 = k[1] | (k[0] << 8);
     uint16_t mediaKeyReport_16 = _mediaKeyReport[1] | (_mediaKeyReport[0] << 8);
@@ -444,7 +444,7 @@ size_t BleKeyboard::release(uint8_t k)
 	return 1;
 }
 
-size_t BleKeyboard::release(const MediaKeyReport k)
+size_t BleKeyboard::release(const BleMediaKeyReport k)
 {
     uint16_t k_16 = k[1] | (k[0] << 8);
     uint16_t mediaKeyReport_16 = _mediaKeyReport[1] | (_mediaKeyReport[0] << 8);
@@ -477,7 +477,7 @@ size_t BleKeyboard::write(uint8_t c)
 	return p;              // just return the result of press() since release() almost always returns 1
 }
 
-size_t BleKeyboard::write(const MediaKeyReport c)
+size_t BleKeyboard::write(const BleMediaKeyReport c)
 {
 	uint16_t p = press(c);  // Keydown
 	release(c);            // Keyup

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -33,100 +33,33 @@
 #define BLE_KEYBOARD_VERSION_MINOR 0
 #define BLE_KEYBOARD_VERSION_REVISION 4
 
-const uint8_t KEY_LEFT_CTRL = 0x80;
-const uint8_t KEY_LEFT_SHIFT = 0x81;
-const uint8_t KEY_LEFT_ALT = 0x82;
-const uint8_t KEY_LEFT_GUI = 0x83;
-const uint8_t KEY_RIGHT_CTRL = 0x84;
-const uint8_t KEY_RIGHT_SHIFT = 0x85;
-const uint8_t KEY_RIGHT_ALT = 0x86;
-const uint8_t KEY_RIGHT_GUI = 0x87;
-
-const uint8_t KEY_UP_ARROW = 0xDA;
-const uint8_t KEY_DOWN_ARROW = 0xD9;
-const uint8_t KEY_LEFT_ARROW = 0xD8;
-const uint8_t KEY_RIGHT_ARROW = 0xD7;
-const uint8_t KEY_BACKSPACE = 0xB2;
-const uint8_t KEY_TAB = 0xB3;
-const uint8_t KEY_RETURN = 0xB0;
-const uint8_t KEY_ESC = 0xB1;
-const uint8_t KEY_INSERT = 0xD1;
-const uint8_t KEY_PRTSC = 0xCE;
-const uint8_t KEY_DELETE = 0xD4;
-const uint8_t KEY_PAGE_UP = 0xD3;
-const uint8_t KEY_PAGE_DOWN = 0xD6;
-const uint8_t KEY_HOME = 0xD2;
-const uint8_t KEY_END = 0xD5;
-const uint8_t KEY_CAPS_LOCK = 0xC1;
-const uint8_t KEY_F1 = 0xC2;
-const uint8_t KEY_F2 = 0xC3;
-const uint8_t KEY_F3 = 0xC4;
-const uint8_t KEY_F4 = 0xC5;
-const uint8_t KEY_F5 = 0xC6;
-const uint8_t KEY_F6 = 0xC7;
-const uint8_t KEY_F7 = 0xC8;
-const uint8_t KEY_F8 = 0xC9;
-const uint8_t KEY_F9 = 0xCA;
-const uint8_t KEY_F10 = 0xCB;
-const uint8_t KEY_F11 = 0xCC;
-const uint8_t KEY_F12 = 0xCD;
-const uint8_t KEY_F13 = 0xF0;
-const uint8_t KEY_F14 = 0xF1;
-const uint8_t KEY_F15 = 0xF2;
-const uint8_t KEY_F16 = 0xF3;
-const uint8_t KEY_F17 = 0xF4;
-const uint8_t KEY_F18 = 0xF5;
-const uint8_t KEY_F19 = 0xF6;
-const uint8_t KEY_F20 = 0xF7;
-const uint8_t KEY_F21 = 0xF8;
-const uint8_t KEY_F22 = 0xF9;
-const uint8_t KEY_F23 = 0xFA;
-const uint8_t KEY_F24 = 0xFB;
-
-const uint8_t KEY_NUM_0 = 0xEA;
-const uint8_t KEY_NUM_1 = 0xE1;
-const uint8_t KEY_NUM_2 = 0xE2;
-const uint8_t KEY_NUM_3 = 0xE3;
-const uint8_t KEY_NUM_4 = 0xE4;
-const uint8_t KEY_NUM_5 = 0xE5;
-const uint8_t KEY_NUM_6 = 0xE6;
-const uint8_t KEY_NUM_7 = 0xE7;
-const uint8_t KEY_NUM_8 = 0xE8;
-const uint8_t KEY_NUM_9 = 0xE9;
-const uint8_t KEY_NUM_SLASH = 0xDC;
-const uint8_t KEY_NUM_ASTERISK = 0xDD;
-const uint8_t KEY_NUM_MINUS = 0xDE;
-const uint8_t KEY_NUM_PLUS = 0xDF;
-const uint8_t KEY_NUM_ENTER = 0xE0;
-const uint8_t KEY_NUM_PERIOD = 0xEB;
-
-typedef uint8_t MediaKeyReport[2];
-
-const MediaKeyReport KEY_MEDIA_NEXT_TRACK = {1, 0};
-const MediaKeyReport KEY_MEDIA_PREVIOUS_TRACK = {2, 0};
-const MediaKeyReport KEY_MEDIA_STOP = {4, 0};
-const MediaKeyReport KEY_MEDIA_PLAY_PAUSE = {8, 0};
-const MediaKeyReport KEY_MEDIA_MUTE = {16, 0};
-const MediaKeyReport KEY_MEDIA_VOLUME_UP = {32, 0};
-const MediaKeyReport KEY_MEDIA_VOLUME_DOWN = {64, 0};
-const MediaKeyReport KEY_MEDIA_WWW_HOME = {128, 0};
-const MediaKeyReport KEY_MEDIA_LOCAL_MACHINE_BROWSER = {0, 1}; // Opens "My Computer" on Windows
-const MediaKeyReport KEY_MEDIA_CALCULATOR = {0, 2};
-const MediaKeyReport KEY_MEDIA_WWW_BOOKMARKS = {0, 4};
-const MediaKeyReport KEY_MEDIA_WWW_SEARCH = {0, 8};
-const MediaKeyReport KEY_MEDIA_WWW_STOP = {0, 16};
-const MediaKeyReport KEY_MEDIA_WWW_BACK = {0, 32};
-const MediaKeyReport KEY_MEDIA_CONSUMER_CONTROL_CONFIGURATION = {0, 64}; // Media Selection
-const MediaKeyReport KEY_MEDIA_EMAIL_READER = {0, 128};
-
-
 //  Low level key report: up to 6 keys and shift, ctrl etc at once
 typedef struct
 {
   uint8_t modifiers;
   uint8_t reserved;
   uint8_t keys[6];
-} KeyReport;
+} BleKeyReport;
+
+typedef uint8_t BleMediaKeyReport[2];
+
+const BleMediaKeyReport KEY_MEDIA_NEXT_TRACK = {1, 0};
+const BleMediaKeyReport KEY_MEDIA_PREVIOUS_TRACK = {2, 0};
+const BleMediaKeyReport KEY_MEDIA_STOP = {4, 0};
+const BleMediaKeyReport KEY_MEDIA_PLAY_PAUSE = {8, 0};
+const BleMediaKeyReport KEY_MEDIA_MUTE = {16, 0};
+const BleMediaKeyReport KEY_MEDIA_VOLUME_UP = {32, 0};
+const BleMediaKeyReport KEY_MEDIA_VOLUME_DOWN = {64, 0};
+const BleMediaKeyReport KEY_MEDIA_WWW_HOME = {128, 0};
+const BleMediaKeyReport KEY_MEDIA_LOCAL_MACHINE_BROWSER = {0, 1}; // Opens "My Computer" on Windows
+const BleMediaKeyReport KEY_MEDIA_CALCULATOR = {0, 2};
+const BleMediaKeyReport KEY_MEDIA_WWW_BOOKMARKS = {0, 4};
+const BleMediaKeyReport KEY_MEDIA_WWW_SEARCH = {0, 8};
+const BleMediaKeyReport KEY_MEDIA_WWW_STOP = {0, 16};
+const BleMediaKeyReport KEY_MEDIA_WWW_BACK = {0, 32};
+const BleMediaKeyReport KEY_MEDIA_CONSUMER_CONTROL_CONFIGURATION = {0, 64}; // Media Selection
+const BleMediaKeyReport KEY_MEDIA_EMAIL_READER = {0, 128};
+
 
 class BleKeyboard : public Print, public BLEServerCallbacks, public BLECharacteristicCallbacks
 {
@@ -136,8 +69,8 @@ private:
   BLECharacteristic* outputKeyboard;
   BLECharacteristic* inputMediaKeys;
   BLEAdvertising*    advertising;
-  KeyReport          _keyReport;
-  MediaKeyReport     _mediaKeyReport;
+  BleKeyReport       _keyReport;
+  BleMediaKeyReport  _mediaKeyReport;
   std::string        deviceName;
   std::string        deviceManufacturer;
   uint8_t            batteryLevel;
@@ -153,14 +86,14 @@ public:
   BleKeyboard(std::string deviceName = "ESP32 Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
   void begin(void);
   void end(void);
-  void sendReport(KeyReport* keys);
-  void sendReport(MediaKeyReport* keys);
+  void sendReport(BleKeyReport* keys);
+  void sendReport(BleMediaKeyReport* keys);
   size_t press(uint8_t k);
-  size_t press(const MediaKeyReport k);
+  size_t press(const BleMediaKeyReport k);
   size_t release(uint8_t k);
-  size_t release(const MediaKeyReport k);
+  size_t release(const BleMediaKeyReport k);
   size_t write(uint8_t c);
-  size_t write(const MediaKeyReport c);
+  size_t write(const BleMediaKeyReport c);
   size_t write(const uint8_t *buffer, size_t size);
   void releaseAll(void);
   bool isConnected(void);

--- a/KeyCodes.h
+++ b/KeyCodes.h
@@ -1,0 +1,71 @@
+#ifndef ESP32_BLE_KEYBOARD_KEYCODES_H
+#define ESP32_BLE_KEYBOARD_KEYCODES_H
+
+const uint8_t KEY_LEFT_CTRL = 0x80;
+const uint8_t KEY_LEFT_SHIFT = 0x81;
+const uint8_t KEY_LEFT_ALT = 0x82;
+const uint8_t KEY_LEFT_GUI = 0x83;
+const uint8_t KEY_RIGHT_CTRL = 0x84;
+const uint8_t KEY_RIGHT_SHIFT = 0x85;
+const uint8_t KEY_RIGHT_ALT = 0x86;
+const uint8_t KEY_RIGHT_GUI = 0x87;
+
+const uint8_t KEY_UP_ARROW = 0xDA;
+const uint8_t KEY_DOWN_ARROW = 0xD9;
+const uint8_t KEY_LEFT_ARROW = 0xD8;
+const uint8_t KEY_RIGHT_ARROW = 0xD7;
+const uint8_t KEY_BACKSPACE = 0xB2;
+const uint8_t KEY_TAB = 0xB3;
+const uint8_t KEY_RETURN = 0xB0;
+const uint8_t KEY_ESC = 0xB1;
+const uint8_t KEY_INSERT = 0xD1;
+const uint8_t KEY_PRTSC = 0xCE;
+const uint8_t KEY_DELETE = 0xD4;
+const uint8_t KEY_PAGE_UP = 0xD3;
+const uint8_t KEY_PAGE_DOWN = 0xD6;
+const uint8_t KEY_HOME = 0xD2;
+const uint8_t KEY_END = 0xD5;
+const uint8_t KEY_CAPS_LOCK = 0xC1;
+const uint8_t KEY_F1 = 0xC2;
+const uint8_t KEY_F2 = 0xC3;
+const uint8_t KEY_F3 = 0xC4;
+const uint8_t KEY_F4 = 0xC5;
+const uint8_t KEY_F5 = 0xC6;
+const uint8_t KEY_F6 = 0xC7;
+const uint8_t KEY_F7 = 0xC8;
+const uint8_t KEY_F8 = 0xC9;
+const uint8_t KEY_F9 = 0xCA;
+const uint8_t KEY_F10 = 0xCB;
+const uint8_t KEY_F11 = 0xCC;
+const uint8_t KEY_F12 = 0xCD;
+const uint8_t KEY_F13 = 0xF0;
+const uint8_t KEY_F14 = 0xF1;
+const uint8_t KEY_F15 = 0xF2;
+const uint8_t KEY_F16 = 0xF3;
+const uint8_t KEY_F17 = 0xF4;
+const uint8_t KEY_F18 = 0xF5;
+const uint8_t KEY_F19 = 0xF6;
+const uint8_t KEY_F20 = 0xF7;
+const uint8_t KEY_F21 = 0xF8;
+const uint8_t KEY_F22 = 0xF9;
+const uint8_t KEY_F23 = 0xFA;
+const uint8_t KEY_F24 = 0xFB;
+
+const uint8_t KEY_NUM_0 = 0xEA;
+const uint8_t KEY_NUM_1 = 0xE1;
+const uint8_t KEY_NUM_2 = 0xE2;
+const uint8_t KEY_NUM_3 = 0xE3;
+const uint8_t KEY_NUM_4 = 0xE4;
+const uint8_t KEY_NUM_5 = 0xE5;
+const uint8_t KEY_NUM_6 = 0xE6;
+const uint8_t KEY_NUM_7 = 0xE7;
+const uint8_t KEY_NUM_8 = 0xE8;
+const uint8_t KEY_NUM_9 = 0xE9;
+const uint8_t KEY_NUM_SLASH = 0xDC;
+const uint8_t KEY_NUM_ASTERISK = 0xDD;
+const uint8_t KEY_NUM_MINUS = 0xDE;
+const uint8_t KEY_NUM_PLUS = 0xDF;
+const uint8_t KEY_NUM_ENTER = 0xE0;
+const uint8_t KEY_NUM_PERIOD = 0xEB;
+
+#endif


### PR DESCRIPTION
Hi, I hit several times collision with other libraries in 2 aspects:
- KeyCodes which were already defined (typically from USB HID libraries).
- KeyReport was already defined (same reason).

To fix it, I moved KeyCodes into separate file as they are not needed in main file and use can control what they want to use this way. And for KeyReport I renamed it (gave it prefix).

This allows to use library with other USB HID libraries. I can make adjustments to my changes if you have better idea how to approach it :)