### PR TITLE
Fix compatibility with String for latest Arduino core

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -16,15 +16,13 @@
 #include <driver/adc.h>
 #include "sdkconfig.h"
 
-
 #if defined(CONFIG_ARDUHAL_ESP_LOG)
-  #include "esp32-hal-log.h"
-  #define LOG_TAG ""
+#include "esp32-hal-log.h"
+#define LOG_TAG ""
 #else
-  #include "esp_log.h"
-  static const char* LOG_TAG = "BLEDevice";
+#include "esp_log.h"
+static const char* LOG_TAG = "BLEDevice";
 #endif
-
 
 // Report IDs:
 #define KEYBOARD_ID 0x01
@@ -95,10 +93,10 @@ static const uint8_t _hidReportDescriptor[] = {
   END_COLLECTION(0)                  // END_COLLECTION
 };
 
-BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer, uint8_t batteryLevel) 
+BleKeyboard::BleKeyboard(String deviceName, String deviceManufacturer, uint8_t batteryLevel) 
     : hid(0)
-    , deviceName(std::string(deviceName).substr(0, 15))
-    , deviceManufacturer(std::string(deviceManufacturer).substr(0,15))
+    , deviceName(deviceName)
+    , deviceManufacturer(deviceManufacturer)
     , batteryLevel(batteryLevel) {}
 
 void BleKeyboard::begin(void)
@@ -119,16 +117,11 @@ void BleKeyboard::begin(void)
   hid->pnp(0x02, vid, pid, version);
   hid->hidInfo(0x00, 0x01);
 
-
 #if defined(USE_NIMBLE)
-
   BLEDevice::setSecurityAuth(true, true, true);
-
 #else
-
   BLESecurity* pSecurity = new BLESecurity();
   pSecurity->setAuthenticationMode(ESP_LE_AUTH_REQ_SC_MITM_BOND);
-
 #endif // USE_NIMBLE
 
   hid->reportMap((uint8_t*)_hidReportDescriptor, sizeof(_hidReportDescriptor));
@@ -161,7 +154,7 @@ void BleKeyboard::setBatteryLevel(uint8_t level) {
 }
 
 //must be called before begin in order to set the name
-void BleKeyboard::setName(std::string deviceName) {
+void BleKeyboard::setName(String deviceName) {
   this->deviceName = deviceName;
 }
 
@@ -468,7 +461,6 @@ void BleKeyboard::releaseAll(void)
     _mediaKeyReport[0] = 0;
     _mediaKeyReport[1] = 0;
 	sendReport(&_keyReport);
-	sendReport(&_mediaKeyReport);
 }
 
 size_t BleKeyboard::write(uint8_t c)

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -138,8 +138,8 @@ private:
   BLEAdvertising*    advertising;
   KeyReport          _keyReport;
   MediaKeyReport     _mediaKeyReport;
-  std::string        deviceName;
-  std::string        deviceManufacturer;
+  String             deviceName;
+  String             deviceManufacturer;
   uint8_t            batteryLevel;
   bool               connected = false;
   uint32_t           _delay_ms = 7;
@@ -150,7 +150,7 @@ private:
   uint16_t version   = 0x0210;
 
 public:
-  BleKeyboard(std::string deviceName = "ESP32 Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
+  BleKeyboard(String deviceName = "ESP32 Keyboard", String deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
   void begin(void);
   void end(void);
   void sendReport(KeyReport* keys);
@@ -165,7 +165,7 @@ public:
   void releaseAll(void);
   bool isConnected(void);
   void setBatteryLevel(uint8_t level);
-  void setName(std::string deviceName);  
+  void setName(String deviceName);  
   void setDelay(uint32_t ms);
 
   void set_vendor_id(uint16_t vid);


### PR DESCRIPTION
Fix compatibility with String for latest Arduino core wouldn't compile with latest betas. 