### PR TITLE
fixed type [std::string to String]

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -103,7 +103,7 @@ BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer,
 
 void BleKeyboard::begin(void)
 {
-  BLEDevice::init(deviceName);
+  BLEDevice::init(String(deviceName.c_str()));
   BLEServer* pServer = BLEDevice::createServer();
   pServer->setCallbacks(this);
 
@@ -114,7 +114,7 @@ void BleKeyboard::begin(void)
 
   outputKeyboard->setCallbacks(this);
 
-  hid->manufacturer()->setValue(deviceManufacturer);
+  hid->manufacturer()->setValue(String(deviceManufacturer.c_str()));
 
   hid->pnp(0x02, vid, pid, version);
   hid->hidInfo(0x00, 0x01);


### PR DESCRIPTION
For better user experience, the type definition of initial device name should be String rather than std::string.