### PR TITLE
syntax errors related to String() when compiling with Arduino IDE 2.3.3

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -95,10 +95,10 @@ static const uint8_t _hidReportDescriptor[] = {
   END_COLLECTION(0)                  // END_COLLECTION
 };
 
-BleKeyboard::BleKeyboard(std::string deviceName, std::string deviceManufacturer, uint8_t batteryLevel) 
+BleKeyboard::BleKeyboard(String deviceName, String deviceManufacturer, uint8_t batteryLevel) 
     : hid(0)
-    , deviceName(std::string(deviceName).substr(0, 15))
-    , deviceManufacturer(std::string(deviceManufacturer).substr(0,15))
+    , deviceName(String(deviceName).substring(0, 15))
+    , deviceManufacturer(String(deviceManufacturer).substring(0,15))
     , batteryLevel(batteryLevel) {}
 
 void BleKeyboard::begin(void)
@@ -161,7 +161,7 @@ void BleKeyboard::setBatteryLevel(uint8_t level) {
 }
 
 //must be called before begin in order to set the name
-void BleKeyboard::setName(std::string deviceName) {
+void BleKeyboard::setName(String deviceName) {
   this->deviceName = deviceName;
 }
 

--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -138,8 +138,8 @@ private:
   BLEAdvertising*    advertising;
   KeyReport          _keyReport;
   MediaKeyReport     _mediaKeyReport;
-  std::string        deviceName;
-  std::string        deviceManufacturer;
+  String        deviceName;
+  String        deviceManufacturer;
   uint8_t            batteryLevel;
   bool               connected = false;
   uint32_t           _delay_ms = 7;
@@ -150,7 +150,7 @@ private:
   uint16_t version   = 0x0210;
 
 public:
-  BleKeyboard(std::string deviceName = "ESP32 Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
+  BleKeyboard(String deviceName = "ESP32 Keyboard", String deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
   void begin(void);
   void end(void);
   void sendReport(KeyReport* keys);
@@ -165,7 +165,7 @@ public:
   void releaseAll(void);
   bool isConnected(void);
   void setBatteryLevel(uint8_t level);
-  void setName(std::string deviceName);  
+  void setName(String deviceName);  
   void setDelay(uint32_t ms);
 
   void set_vendor_id(uint16_t vid);


### PR DESCRIPTION
Errors when compiling in Arduino IDE 2.3.3 like the following:

```
/Users/chuck/Documents/Arduino/libraries/ESP32_BLE_Keyboard/BleKeyboard.cpp:106:19: error: cannot convert 'std::string' {aka 'std::__cxx11::basic_string<char>'} to 'String'
  106 |   BLEDevice::init(deviceName);
      |                   ^~~~~~~~~~
      |                   |
      |                   std::string {aka std::__cxx11::basic_string<char>}

```

and

```
/Users/chuck/Documents/Arduino/libraries/ESP32_BLE_Keyboard/BleKeyboard.cpp: In constructor 'BleKeyboard::BleKeyboard(String, String, uint8_t)':
/Users/chuck/Documents/Arduino/libraries/ESP32_BLE_Keyboard/BleKeyboard.cpp:101:37: error: 'class String' has no member named 'substr'
  101 |     , deviceName(String(deviceName).substr(0, 15))
      |                                     ^~~~~~
```
Reference to #322.