### PR TITLE
Compatibility with Arduino

### DIFF
--- a/BleKeyboard.h
+++ b/BleKeyboard.h
@@ -1,6 +1,3 @@
-// uncomment the following line to use NimBLE library
-//#define USE_NIMBLE
-
 #ifndef ESP32_BLE_KEYBOARD_H
 #define ESP32_BLE_KEYBOARD_H
 #include "sdkconfig.h"
@@ -28,10 +25,6 @@
 
 #include "Print.h"
 
-#define BLE_KEYBOARD_VERSION "0.0.4"
-#define BLE_KEYBOARD_VERSION_MAJOR 0
-#define BLE_KEYBOARD_VERSION_MINOR 0
-#define BLE_KEYBOARD_VERSION_REVISION 4
 
 const uint8_t KEY_LEFT_CTRL = 0x80;
 const uint8_t KEY_LEFT_SHIFT = 0x81;
@@ -51,7 +44,6 @@ const uint8_t KEY_TAB = 0xB3;
 const uint8_t KEY_RETURN = 0xB0;
 const uint8_t KEY_ESC = 0xB1;
 const uint8_t KEY_INSERT = 0xD1;
-const uint8_t KEY_PRTSC = 0xCE;
 const uint8_t KEY_DELETE = 0xD4;
 const uint8_t KEY_PAGE_UP = 0xD3;
 const uint8_t KEY_PAGE_DOWN = 0xD6;
@@ -82,23 +74,6 @@ const uint8_t KEY_F21 = 0xF8;
 const uint8_t KEY_F22 = 0xF9;
 const uint8_t KEY_F23 = 0xFA;
 const uint8_t KEY_F24 = 0xFB;
-
-const uint8_t KEY_NUM_0 = 0xEA;
-const uint8_t KEY_NUM_1 = 0xE1;
-const uint8_t KEY_NUM_2 = 0xE2;
-const uint8_t KEY_NUM_3 = 0xE3;
-const uint8_t KEY_NUM_4 = 0xE4;
-const uint8_t KEY_NUM_5 = 0xE5;
-const uint8_t KEY_NUM_6 = 0xE6;
-const uint8_t KEY_NUM_7 = 0xE7;
-const uint8_t KEY_NUM_8 = 0xE8;
-const uint8_t KEY_NUM_9 = 0xE9;
-const uint8_t KEY_NUM_SLASH = 0xDC;
-const uint8_t KEY_NUM_ASTERISK = 0xDD;
-const uint8_t KEY_NUM_MINUS = 0xDE;
-const uint8_t KEY_NUM_PLUS = 0xDF;
-const uint8_t KEY_NUM_ENTER = 0xE0;
-const uint8_t KEY_NUM_PERIOD = 0xEB;
 
 typedef uint8_t MediaKeyReport[2];
 
@@ -138,19 +113,15 @@ private:
   BLEAdvertising*    advertising;
   KeyReport          _keyReport;
   MediaKeyReport     _mediaKeyReport;
-  std::string        deviceName;
-  std::string        deviceManufacturer;
+  String        deviceName;
+  String        deviceManufacturer;
   uint8_t            batteryLevel;
   bool               connected = false;
   uint32_t           _delay_ms = 7;
   void delay_ms(uint64_t ms);
 
-  uint16_t vid       = 0x05ac;
-  uint16_t pid       = 0x820a;
-  uint16_t version   = 0x0210;
-
 public:
-  BleKeyboard(std::string deviceName = "ESP32 Keyboard", std::string deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
+  BleKeyboard(String deviceName = "ESP32 Keyboard", String deviceManufacturer = "Espressif", uint8_t batteryLevel = 100);
   void begin(void);
   void end(void);
   void sendReport(KeyReport* keys);
@@ -165,12 +136,8 @@ public:
   void releaseAll(void);
   bool isConnected(void);
   void setBatteryLevel(uint8_t level);
-  void setName(std::string deviceName);  
+  void setName(String deviceName);  
   void setDelay(uint32_t ms);
-
-  void set_vendor_id(uint16_t vid);
-  void set_product_id(uint16_t pid);
-  void set_version(uint16_t version);
 protected:
   virtual void onStarted(BLEServer *pServer) { };
   virtual void onConnect(BLEServer* pServer) override;


### PR DESCRIPTION
Updated BleKeyboard.h and BleKeyboard.cpp:
1. Arduino uses String instead of std::string
2. String class in Arduino does not have a substr() method like std::string in C++. Instead, use substring()