### PR TITLE
Fix for Issue #383

### DIFF
--- a/BleKeyboard.cpp
+++ b/BleKeyboard.cpp
@@ -524,9 +524,9 @@ void BleKeyboard::onDisconnect(BLEServer* pServer) {
   desc = (BLE2902*)this->inputMediaKeys->getDescriptorByUUID(BLEUUID((uint16_t)0x2902));
   desc->setNotifications(false);
 
-  advertising->start();
-
 #endif // !USE_NIMBLE
+	
+  advertising->start();
 }
 
 void BleKeyboard::onWrite(BLECharacteristic* me) {


### PR DESCRIPTION
Issue https://github.com/T-vK/ESP32-BLE-Keyboard/issues/84 does still exists when using NimBLE.
Namely, the fix is disabled when using NimBLE.